### PR TITLE
fix: Redirects from the RDAP server were causing an SSL EOF error

### DIFF
--- a/lib/ip_contact_finder/rdap.rb
+++ b/lib/ip_contact_finder/rdap.rb
@@ -55,6 +55,7 @@ module IPContactFinder
 
       @logger&.info "Making request to #{uri}"
 
+      http.start
       response = http.request(request)
       @logger&.info "Got response #{response.code}"
 
@@ -74,6 +75,8 @@ module IPContactFinder
     rescue SocketError, Errno::ECONNRESET, EOFError, Errno::EINVAL, Errno::ENETUNREACH, Errno::EHOSTUNREACH,
            Errno::ECONNREFUSED, OpenSSL::SSL::SSLError, Timeout::Error => e
       raise RequestError, "#{e.message} (#{e.class})"
+    ensure
+      http.finish
     end
   end
 end


### PR DESCRIPTION
The root of the issue appears to be a change made in later versions of OpenSSL that raises a `SSL_read: unexpected eof while reading` if the server sends an `EOF` before sending `close notify`

see https://github.com/openssl/openssl/issues/11378

It seems that `Net::HTTP` can handle this situation when the session is manually started (`http.start`) but not when it is auto started as soon as the request is made. This may be a bug in `Net::HTTP``, and something I'd like to investigate further given time, but for now manually starting session fixes the issue